### PR TITLE
Fixed slow start and creating lots of duplicates

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ const Ticker: React.FunctionComponent<TickerProps> = (props: TickerProps) => {
   } = props;
   const tickerRef = React.useRef<HTMLDivElement>(null);
   const [tickerUUID, setTickerUUID] = React.useState<string>('');
-  const [tickerContentWidth, setTickerContentWidth] = React.useState<number>(2);
+  const [tickerContentWidth, setTickerContentWidth] = React.useState<number | null>(0);
   const [numDupes, setNumDupes] = React.useState<number>(1);
   const [scope, animate] = useAnimate();
   const [animationControls, setAnimationControls] = React.useState<
@@ -62,7 +62,7 @@ const Ticker: React.FunctionComponent<TickerProps> = (props: TickerProps) => {
     if (isInView && !animationControls) {
       const controls = animate(
         scope.current,
-        { x: tickerContentWidth * direction },
+        { x: tickerContentWidth ? tickerContentWidth * direction : 0 },
         { ease: 'linear', duration, repeat: Infinity }
       );
       controls.play();


### PR DESCRIPTION
Because the tickerContentWidth was 2 by default the code below would run immediate and give back a big numDupes.
By setting it to null by default it waits until it gets a tickerContentWidth and the amount of numDupes is smaller.
It slows down the application because it had to render a lot of components.

```
if (tickerRef.current && tickerContentWidth) {
  setNumDupes(Math.max(Math.ceil((2 * tickerRef.current.clientWidth) / tickerContentWidth), 1));
}
```